### PR TITLE
Adding target tools python scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 .vscode/
 *.code-workspace
 
+# PyCharm
+.idea/
+

--- a/README.md
+++ b/README.md
@@ -2,18 +2,48 @@
 
 OSGeoLive-docの日本語翻訳を、OmegaTという翻訳支援ソフトを利用して進めるプロジェクトです。
 
-## 作業メモ(macOS環境, 暫定)
+## OmegaTの設定
 
-1. Translate Toolkitのインストール
+OSGeoLive翻訳管理(https://docs.google.com/spreadsheets/d/1FyDI0iaG-v-VsocWrUyDmfabBbb5CD08VNrTTdhgcgQ/edit?usp=sharing) の [翻訳の手順] シートの内容をチェックしてください。
 
+## 管理者メンテナンス作業
+
+※将来的にはGitHub Actionsに移行の予定です。
+
+### Python関連ライブラリのインストール
+
+```bash
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
+```
+
+### 訳文のreST文法チェック
+
+1. OmegaTの [環境設定] より、 [編集] / [原文と同じ訳文を許可] をチェックONし、 [確定] ボタンをクリック
+2. OmegaT上での翻訳作業で一区切りついたら、 [プロジェクト] / [訳文ファイルを生成] メニューを選択して、訳文ファイルを生成
+3. ターミナル上で下記を実行して、reST文法にエラーがないか確認
    ```bash
-   $ python3 -m venv venv
    $ source venv/bin/activate
-   $ pip install -r requirements.txt
+   $ python3 tools/check_target.py [訳文フォルダのパス(デフォルト: target)]
    ```
-2. 最新の翻訳済みpoファイルをsourceフォルダにコピー  
-   OSGeo-jpのOSGeoLive-docリポジトリ(https://github.com/OSGeo-jp/OSGeoLive-doc/tree/ja_all_po_files) の `ja_all_po_files` ブランチより、 `locale/ja/LC_MESSAGES` を `source` フォルダにコピー
-3. poファイルからtmxファイルに変換
+4. reST文法エラーがある場合は、翻訳を修正し、上記2~3の手順を再度実施
+
+### OSGeoLive-doc / Transifex からの原文の同期
+
+1. 最新の翻訳済みpoファイルを `source` フォルダにコピー  
+   OSGeo-jpのOSGeoLive-docリポジトリ(https://github.com/OSGeo-jp/OSGeoLive-doc) の `transifex_ja` ブランチより、 `locale/ja/LC_MESSAGES` を `source` フォルダにコピー
+2. poファイルからtmxファイルに変換(※必要に応じて実施)
    ```bash
-   bash tools/po2tmxconv.sh
+   $ bash tools/po2tmxconv.sh
    ```
+3. `source` フォルダ内の追加・変更分をGitでコミット・プッシュ
+
+### Transifex への訳文のアップロード
+
+1. ターミナル上で下記を実行して、訳文をフォーマット
+   ```bash
+   $ source venv/bin/activate
+   $ python3 tools/format_target.py [原文フォルダのパス(デフォルト: source)] [訳文フォルダのパス(デフォルト: target)]
+   ```
+2. `source` フォルダと `target` フォルダを比較して、有意な変更のあった訳文ファイルのみ、Transifexにアップロード

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 translate-toolkit[all]
 lxml
-
+polib
+attrdict
+docutils==0.16
+Babel==2.8.0

--- a/tools/check_target.py
+++ b/tools/check_target.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python3
-# coding=utf-8
+#!/usr/bin/env python3
 
 # Referred mint-check-translations, but changed much
 # https://github.com/linuxmint/mint-dev-tools/blob/master/usr/bin/mint-check-translations

--- a/tools/check_target.py
+++ b/tools/check_target.py
@@ -50,12 +50,6 @@ class Main:
             exit(1)
 
     def load_files(self):
-        num_files = 0
-        for root, subFolders, files in os.walk(self.args.directory, topdown=False):
-            for file in files:
-                if file.endswith(PO_EXT):
-                    num_files += 1
-
         count_files = 0
         for root, subFolders, files in os.walk(self.args.directory, topdown=False):
             for file in files:

--- a/tools/check_target.py
+++ b/tools/check_target.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python3
+# coding=utf-8
+
+# Referred mint-check-translations, but changed much
+# https://github.com/linuxmint/mint-dev-tools/blob/master/usr/bin/mint-check-translations
+
+import argparse
+import polib
+import os
+from attrdict import AttrDict
+from docutils.parsers.rst.states import Inliner, Struct
+from docutils.utils import Reporter, new_document
+from io import StringIO
+
+PO_EXT = ".po"
+
+# GOOD = 0
+# RST_SCHAR_MISMATCH = 200
+
+
+class Po:
+    def __init__(self, inst, file, path):
+        self.inst = inst
+        self.file = file.replace(".po", "")
+        self.current_index = 1
+
+
+class Main:
+    def __init__(self):
+        parser = argparse.ArgumentParser(description='Check translation files')
+        parser.add_argument('directory', nargs='?', default=os.getcwd(), help="A directory to check (default is to check the current working directory)")
+        self.args = parser.parse_args()
+        self.type = PO_EXT
+        self.load_files()
+
+    def print_issue(self, po, msgid, msgstr, issue, current_index):
+        # print("po: %s" % po)
+        print("==========================")
+        print("file: %s" % po.file)
+        print("msgid: %s" % msgid)
+        print("msgstr: %s" % msgstr)
+        print("issue: %s" % issue)
+        # print("current_index: %s" % current_index)
+
+    def load_files(self):
+        num_files = 0
+        for root, subFolders, files in os.walk(self.args.directory, topdown=False):
+            for file in files:
+                if file.endswith(PO_EXT):
+                    num_files += 1
+
+        count_files = 0
+        for root, subFolders, files in os.walk(self.args.directory, topdown=False):
+            for file in files:
+                if file.endswith(PO_EXT):
+                    po_inst = polib.pofile(os.path.join(root, file))
+                    po = Po(po_inst, file, os.path.join(root, file))
+                else:
+                    continue
+                count_files += 1
+                self.check_file(po)
+
+    def check_file(self, po):
+        for entry in po.inst:
+            if entry.obsolete:
+                continue  # skip obsolete translations (prefixed with #~ in po file)
+            issue_found = False
+            msgid = entry.msgid
+            msgstr = entry.msgstr
+            if ".rst" in str(entry):
+                # restructuredtext
+                # for special_char in ["``", "<", ">", "_", "-->", ":kbd:", ":guilabel:", "`"]:
+                #     if msgstr != "" and msgid.count(special_char) != msgstr.count(special_char):
+                #         issue_found = True
+                #         res = "Mismatch in RST special chars"
+                #         break
+                # Sphinx build equivalent
+                res = self.check_docutils_inliner(po, msgstr)
+                if len(res) > 0:
+                    issue_found = True
+
+            if issue_found:
+                self.print_issue(po, msgid, msgstr, res, po.current_index)
+            po.current_index += 1
+
+    def check_docutils_inliner(self, po, msgstr):
+        inliner = Inliner()
+        settings = AttrDict({'character_level_inline_markup': False, 'pep_references': None, 'rfc_references': None})
+        inliner.init_customizations(settings)
+        document = new_document(None)
+        document.settings.syntax_highlight = 'long'
+        stream = StringIO()
+        reporter = Reporter(po.file, report_level=Reporter.WARNING_LEVEL,
+                            halt_level=Reporter.SEVERE_LEVEL, stream=stream)
+        memo = Struct(document=document, reporter=reporter, language=None, inliner=inliner)
+        inliner.parse(msgstr, po.current_index, memo, None)
+        return stream.getvalue()
+
+
+if __name__ == "__main__":
+    Main()

--- a/tools/format_target.py
+++ b/tools/format_target.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import io
+
+from babel.messages import pofile
+
+PO_EXT = ".po"
+
+
+def load_catalogs(top_dir):
+    catalogs = {}
+    for root, dirs, files in os.walk(top_dir, topdown=False):
+        for file in files:
+            if file.endswith(PO_EXT):
+                path = os.path.join(root, file)
+                rel_path = os.path.relpath(path, top_dir)
+                with io.open(path, 'rb') as f:
+                    catalogs[rel_path] = pofile.read_po(f)
+            else:
+                continue
+    return catalogs
+
+
+def load_lines_with_header_len(path):
+    with open(path) as f:
+        lines = f.readlines()
+    header_len = lines.index('\n') if '\n' in lines else len(lines)
+    return lines, header_len
+
+
+def main(args):
+    # Load source/target po files
+    source_catalogs = load_catalogs(args.source)
+    target_catalogs = load_catalogs(args.target)
+
+    # Fill/format target catalogs
+    for path in source_catalogs:
+        source_catalog = source_catalogs[path]
+        source_path = os.path.join(args.source, path)
+        if path in target_catalogs:
+            target_path = os.path.join(args.target, path)
+            print(target_path)
+            target_catalog = target_catalogs[path]
+            # target_catalog.header_comment = source_catalog.header_comment
+            # target_catalog.fuzzy = source_catalog.fuzzy
+            # target_catalog.mime_headers = source_catalog.mime_headers
+            for source_message in source_catalog:
+                if source_message.id == source_message.string:
+                    target_message = target_catalog.get(source_message.id)
+                    if target_message is not None and len(target_message.string) == 0:
+                        target_message.string = target_message.id
+                        print("\t'%s' is filled" % target_message.string)
+
+            # Write target once
+            with io.open(target_path, 'wb') as f:
+                pofile.write_po(f, target_catalog, width=79)
+
+            # Copy headers
+            source_lines, source_header_len = load_lines_with_header_len(source_path)
+            target_lines, target_header_len = load_lines_with_header_len(target_path)
+            final_lines = source_lines[0:source_header_len] + target_lines[target_header_len:]
+            with open(target_path, mode='w') as f:
+                f.writelines(final_lines)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Format target files')
+    parser.add_argument('source', nargs='?', default='./source',
+                        help="A source directory to compare (default is './source')")
+    parser.add_argument('target', nargs='?', default='./target',
+                        help="A target directory to format (default is './target')")
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
`target` フォルダ内のreST文法チェックについては、下記コメントで参照予定だったLinux Mint用のチェックツールでは不十分だったため、Sphinx Buildの内部で利用されているDocutilsの `Inliner` オブジェクトのチェックを利用する形で対応中。

https://github.com/OSGeo-jp/OSGeoLive-doc-omegat/issues/4#issuecomment-733270529
> 自動検出Pythonスクリプトは、下記のLinux Mint用のチェックツールを、GTKなし、POファイル以外のチェックなしで動作するようにしようかと考えています。
> 
> - https://linuxmint-translation-guide.readthedocs.io/en/latest/verify.html
> - https://github.com/linuxmint/mint-dev-tools/blob/master/usr/bin/mint-check-translations

---

現状、 `:doc:` などのDocutilsでのRole?箇所について、文法的に合っていてもエラーとして弾かれてしまっているため、こちらを通す処理が必要。
```
==========================
file: mapproxy_overview
msgid: :doc:`Quickstart documentation <../quickstart/mapproxy_quickstart>`
msgstr: :doc:`クイックスタート文書 <../quickstart/mapproxy_quickstart>`
issue: mapproxy_overview:64: (ERROR/3) Unknown interpreted text role "doc".
```

---

追加で、Sphinx Buildの解析中、Poファイルの `msgstr` 箇所のフォーマット処理にBabelを利用すれば良さそうなことも検討が付いたため、こちらも合わせて来週末に対応予定。