### PR TITLE
gha: enable cache

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           arguments: translate
           gradle-version: wrapper
+          save-gradle-dependencies-cache: true
       - name: Check translations
         run: |
            python tools/check_target.py


### PR DESCRIPTION
Gradleの実行にもっとも時間がかかっています。cache機能が無効のためのようです。
そのため、依存モジュールについてのcacheを有効にします。

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
