### PR TITLE
Fix checksum of zip file not jar

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=e996d452d2645e70c01c11143ca2d3742734a28da2bf61f25c82bdc288c9e637
+distributionSha256Sum=3239b5ed86c3838a37d983ac100573f64c1f3fd8e1eb6c89fa5f9529b5ec091d
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
checksum は、zipのものを指定するところをjar のsha256を記載していたため、その修正。

ただしい値は以下で確認した。
https://gradle.org/release-checksums/

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
