### PR TITLE
CI: add progress percentage for test

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,3 +52,8 @@ jobs:
       - name: Check translations
         run: |
            python tools/check_target.py
+      - name: Report coverage
+        uses: miurahr/omegat-stat@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage: 50.0


### PR DESCRIPTION
It checks translation coverage(progress). now I set progress lower limit as 50%.
When become lower than 50%, test is failed.

It also add coverage comment as test for commit.

このPRでは、テストとして、翻訳の進捗を報告するようにする変更を提案します。
OmegaTでは、 omegat/project_stats.txt に、統計情報が出力されます。
これを取得して、Github actionsの結果レポートをおこなう アクションを作成したので、それを実行します。

閾値より、翻訳率がさがると、テストは失敗するほか、統計情報についてテスト結果として、報告します。

Signed-off-by: Hiroshi Miura <miurahr@linux.com>