### PR TITLE
Changed doc repository user/organization to same one

### DIFF
--- a/.github/workflows/invoke.yml
+++ b/.github/workflows/invoke.yml
@@ -13,5 +13,5 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: Pull OmegaT after check update
-          repo: OSGeo-jp/OSGeoLive-doc
+          repo: ${GITHUB_ACTOR}/OSGeoLive-doc
           token: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/invoke.yml
+++ b/.github/workflows/invoke.yml
@@ -13,5 +13,5 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: Pull OmegaT after check update
-          repo: ${GITHUB_ACTOR}/OSGeoLive-doc
+          repo: ${{ github.actor }}/OSGeoLive-doc
           token: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout OSGeoLive-doc
         uses: actions/checkout@v2
         with:
-          repository: ${GITHUB_ACTOR}/OSGeoLive-doc
+          repository: ${{ github.actor }}/OSGeoLive-doc
           ref: transifex_ja
           path: doc
 

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout OSGeoLive-doc
         uses: actions/checkout@v2
         with:
-          repository: OSGeo-jp/OSGeoLive-doc
+          repository: ${GITHUB_ACTOR}/OSGeoLive-doc
           ref: transifex_ja
           path: doc
 


### PR DESCRIPTION
invoke/pull ワークフローの参照先の `doc` 側のリポジトリを、 `OSGeo-jp` 固定でなく、同じGitHubユーザ・組織のリポジトリに変更します。

ローカル(@sanak)で、 `doc` 側と合わせて動作確認後、マージします。